### PR TITLE
Use current version for build

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -6,7 +6,7 @@ on:
         type: string
         required: false
         default: ""
-      elixir-version: 
+      elixir-version:
         type: string
         required: false
         default: "1.14.3" # Define the elixir version
@@ -14,7 +14,7 @@ on:
         type: string
         required: false
         default: "25.1" # Define the OTP version
-      mix-env: 
+      mix-env:
         type: string
         required: false
         default: test
@@ -31,7 +31,7 @@ env:
 jobs:
   build:
     name: Build
-    uses: coingaming/.github/.github/workflows/build.yml@v1.1.0
+    uses: ./.github/workflows/build.yml
     secrets: inherit
     with:
       mix-env: ${{ inputs.mix-env }}

--- a/.github/workflows/dialyzer.yml
+++ b/.github/workflows/dialyzer.yml
@@ -6,7 +6,7 @@ on:
         type: string
         required: false
         default: ""
-      elixir-version: 
+      elixir-version:
         type: string
         required: false
         default: "1.14.3" # Define the elixir version
@@ -14,7 +14,7 @@ on:
         type: string
         required: false
         default: "25.1" # Define the OTP version
-      mix-env: 
+      mix-env:
         type: string
         required: false
         default: test
@@ -32,7 +32,7 @@ env:
 jobs:
   build:
     name: Build
-    uses: coingaming/.github/.github/workflows/build.yml@v1.1.0
+    uses: ./.github/workflows/build.yml@v1.1.0
     secrets: inherit
     with:
       mix-env: ${{ inputs.mix-env }}

--- a/.github/workflows/release-hex-manual.yml
+++ b/.github/workflows/release-hex-manual.yml
@@ -9,15 +9,15 @@ on:
         type: string
         required: false
         default: ""
-      elixir-version: 
+      elixir-version:
         type: string
         required: false
-        default: "1.14.3" # Define the elixir version 
-      otp-version: 
+        default: "1.14.3" # Define the elixir version
+      otp-version:
         type: string
         required: false
         default: "25.1" # Define the OTP version
-      mix-env: 
+      mix-env:
         type: string
         required: false
         default: test
@@ -35,7 +35,7 @@ env:
 jobs:
   build:
     name: Build
-    uses: coingaming/.github/.github/workflows/build.yml@v1.1.1
+    uses: ./.github/workflows/build.yml
     secrets: inherit
     with:
       ref: ${{ inputs.version }}

--- a/.github/workflows/release-hex.yml
+++ b/.github/workflows/release-hex.yml
@@ -6,15 +6,15 @@ on:
         type: string
         required: false
         default: ""
-      elixir-version: 
+      elixir-version:
         type: string
         required: false
-        default: "1.14.3" # Define the elixir version 
-      otp-version: 
+        default: "1.14.3" # Define the elixir version
+      otp-version:
         type: string
         required: false
         default: "25.1" # Define the OTP version
-      mix-env: 
+      mix-env:
         type: string
         required: false
         default: test
@@ -32,7 +32,7 @@ env:
 jobs:
   build:
     name: Build
-    uses: coingaming/.github/.github/workflows/build.yml@v1.1.0
+    uses: ./.github/workflows/build.yml
     secrets: inherit
     with:
       mix-env: ${{ inputs.mix-env }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,7 @@ on:
         type: string
         required: false
         default: ""
-      elixir-version: 
+      elixir-version:
         type: string
         required: false
         default: "1.14.3" # Define the elixir version
@@ -14,7 +14,7 @@ on:
         type: string
         required: false
         default: "25.1" # Define the OTP version
-      mix-env: 
+      mix-env:
         type: string
         required: false
         default: test
@@ -32,7 +32,7 @@ env:
 jobs:
   build:
     name: Build
-    uses: coingaming/.github/.github/workflows/build.yml@v1.1.0
+    uses: ./.github/workflows/build.yml
     secrets: inherit
     with:
       mix-env: ${{ inputs.mix-env }}


### PR DESCRIPTION
Currently, code-checks, dialyzer, etc, depend on an old version of `build.yml`. 
This PR makes they always depend on the same version of `build.yml`, by using the local file instead of fetching the workflow externally.